### PR TITLE
Adds YYYY to birthdate and drupal_register_date

### DIFF
--- a/lib/users.js
+++ b/lib/users.js
@@ -24,7 +24,10 @@ Users.prototype.get = function(req, res) {
   // Build the query based on the params received.
   var query = {};
   if (req.query.birthdate !== undefined) {
-    var birthdate = new Date(req.query.birthdate);
+    // Date expects new Date("Month dd, yyyy")
+    var currentYear = new Date().getFullYear();
+    var targetDate = req.query.birthdate + ', ' + currentYear;
+    var birthdate = new Date(targetDate);
 
     query.birthdate = {
       day: birthdate.getDate(),
@@ -33,7 +36,11 @@ Users.prototype.get = function(req, res) {
   }
 
   if (req.query.drupal_register_date !== undefined) {
-    var drupalRegisterDate = new Date(req.query.drupal_register_date);
+    // Date expects new Date("Month dd, yyyy")
+    var currentYear = new Date().getFullYear();
+    var targetDate = req.query.drupal_register_date + ', ' + currentYear;
+    var drupalRegisterDate = new Date(targetDate);
+
     query.drupal_register_date = {
       day: drupalRegisterDate.getDate(),
       month: drupalRegisterDate.getMonth()


### PR DESCRIPTION
Fixes #17 

Adds YYYY to `birthdate` and `drupal_register_date` parameter values passed to the API.
- Wiki needs to be updated with expected values for `birthdate` and `drupal_register_date` which is: `Month dd` In order for this work as a parameter perhaps it needs to be url encoded to `Month+dd` and decoded before pass the value to `Date()`?
