### PR TITLE
Converting campaign signup and reportback timestamps to milliseconds

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -15,6 +15,16 @@ function User(model) {
 }
 
 /**
+ * Converts a timestamp in seconds to a Date object.
+ *
+ * @param timestamp
+ *   Timestamp in seconds.
+ */
+var convertToDate = function(timestamp) {
+  return new Date(timestamp * 1000);
+};
+
+/**
  * Finds a user document for a given email.
  *
  * @param req
@@ -113,21 +123,30 @@ User.prototype.post = function(req, res) {
       if (self.request.body.drupal_register_timestamp !== undefined) {
         // Convert timestamp string to Date object
         var timestamp = parseInt(self.request.body.drupal_register_timestamp);
-        // Date() expects milliseconds
-        var drupalRegisterDate = new Date(timestamp * 1000);
-        updateArgs['$set'].drupal_register_date = drupalRegisterDate;
+        updateArgs['$set'].drupal_register_date = convertToDate(timestamp);
       }
 
       if (self.request.body.birthdate_timestamp !== undefined) {
         var timestamp = parseInt(self.request.body.birthdate_timestamp);
-        var birthdate = new Date(timestamp * 1000);
-        updateArgs['$set'].birthdate = birthdate;
+        updateArgs['$set'].birthdate = convertToDate(timestamp);
       }
 
       // @todo Look into using $push for updating the 'campaigns' array
       // If there are campaigns to update, we need to handle on our own how
       // that field gets updated in the document.
       if (self.request.body.campaigns !== undefined) {
+
+        // Convert timestamps to Date objects.
+        for(var i = 0; i < self.request.body.campaigns.length; i++) {
+          var reqCampaign = self.request.body.campaigns[i];
+            if (reqCampaign.signup !== undefined) {
+              self.request.body.campaigns[i].signup = convertToDate(reqCampaign.signup);
+            }
+            if (reqCampaign.reportback !== undefined) {
+              self.request.body.campaigns[i].reportback = convertToDate(reqCampaign.reportback);
+            }
+        }
+
         if (doc && doc.campaigns !== undefined) {
           // Add old campaigns data to ensure it doesn't get lost.
           updateArgs.campaigns = doc.campaigns;
@@ -137,14 +156,6 @@ User.prototype.post = function(req, res) {
 
             var matchFound = false;
             var reqCampaign = self.request.body.campaigns[i];
-            // Convert timestamps to Date objects. Timestamps are getting provided
-            // in seconds, but we need milliseconds for creating the Date object.
-            if (reqCampaign.signup !== undefined) {
-              reqCampaign.signup = new Date(reqCampaign.signup * 1000);
-            }
-            if (reqCampaign.reportback !== undefined) {
-              reqCampaign.reportback = new Date(reqCampaign.reportback * 1000);
-            }
 
             for (var j = 0; j < updateArgs.campaigns.length; j++) {
 


### PR DESCRIPTION
Timestamps received are in seconds.

Fixes #35 
