### PR TITLE
Adding first_name and last_name to docs returned in queries

### DIFF
--- a/lib/users.js
+++ b/lib/users.js
@@ -37,6 +37,7 @@ Users.prototype.get = function(req, res) {
           month: {$month: '$birthdate'},
           day: {$dayOfMonth: '$birthdate'},
           year: {$year: '$birthdate'},
+          drupal_uid: '$drupal_uid',
           email: '$email',
           first_name: '$first_name',
           last_name: '$last_name'
@@ -57,6 +58,7 @@ Users.prototype.get = function(req, res) {
           month: {$month: '$birthdate'},
           day: {$dayOfMonth: '$birthdate'},
           year: {$year: '$birthdate'},
+          drupal_uid: '$drupal_uid',
           email: '$email',
           first_name: '$first_name',
           last_name: '$last_name'
@@ -84,6 +86,7 @@ Users.prototype.get = function(req, res) {
           month: {$month: '$drupal_register_date'},
           day: {$dayOfMonth: '$drupal_register_date'},
           year: {$year: '$drupal_register_date'},
+          drupal_uid: '$drupal_uid',
           email: '$email',
           first_name: '$first_name',
           last_name: '$last_name'
@@ -104,6 +107,7 @@ Users.prototype.get = function(req, res) {
           month: {$month: '$drupal_register_date'},
           day: {$dayOfMonth: '$drupal_register_date'},
           year: {$year: '$drupal_register_date'},
+          drupal_uid: '$drupal_uid',
           email: '$email',
           first_name: '$first_name',
           last_name: '$last_name'


### PR DESCRIPTION
Birthdate and anniversary date queries will now include the first_name and last_name of each user if it's set. The attribute won't be returned if it has not been set.

@DeeZone did you want any other attributes returned?
