### PR TITLE
Method added to retrieve all users

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Parameters _(optional)_:
 - `pageSize`: Number  # For pagination. Requires `page` to be set. Sets the page size. _Default_: 100  
 - `limit`: Number  # Limits the number of results returned. _Default_: 100  
 - `includeUnsubscribed`: Number  # Set to 1 to include users who are unsubscribed.
+- `excludeNoCampaigns`: Number  # Set to 1 to exclude users who have no campaign actions.
 
 Example query: `\Users?page=10&pageSize=100&limit=50`
 Response: JSON array that includes query details and an array of user documents found.

--- a/lib/users.js
+++ b/lib/users.js
@@ -47,6 +47,11 @@ var getAllUsers = function(request, response, self) {
     };
   }
 
+  // Only return users who have taken campaign actions.
+  if (request.query.excludeNoCampaigns == 1) {
+    conditions['campaigns'] = {$exists: true};
+  }
+
   var usingCustomPage = false,
       usingCustomPageSize = false,
       usingCustomLimit = false;


### PR DESCRIPTION
@DeeZone `/users GET` will now give you results!

New params were added that you can use with it:
`limit`: This will limit the number of results you get back. Default is 100.
`page`: The page number you want to skip to. Default is 1.
`pageSize`: The size of the pages. Default is 100.

Other things:
- the birthdate and drupal_register_date GET logic got moved into their own methods
- hm, i guess that's it for other things

Closes #45
