### PR TITLE
Adds exactCase support

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -208,7 +208,12 @@ User.prototype.post = function(req, res) {
  */
 User.prototype.delete = function(request, response) {
   var self = this;
-  self.email = request.query.email.toLowerCase();
+  if (request.query.exactCase == 1) {
+    self.email = request.query.email;
+  }
+  else {
+    self.email = request.query.email.toLowerCase();
+  }
   self.response = response;
 
   this.docModel.remove(


### PR DESCRIPTION
Fixes #60 

Adds support for `exactCase` parameter.

**To test:**
- Check for duplicate entries:
  - `db['mailchimp-users'].find({email : "Hbush1987@gmail.com"}).pretty()`
  -  `db['mailchimp-users'].find({email : "hbush1987@gmail.com"}).pretty()`
- POST DELETE cURL request to `http://localhost:4722/user?email=Hbush1987@gmail.com&exactCase=1`

**Results**

```
Delete 1 document(s) for email: Hbush1987@gmail.com
```

**Confirm results**:
- `db['mailchimp-users'].find({email : "Hbush1987@gmail.com"}).pretty()`
- `db['mailchimp-users'].find({email : "hbush1987@gmail.com"}).pretty()`
- Confirm only the upper case entry is removed
