### PR TITLE
Convert signup_application_id to source

### DIFF
--- a/lib/users.js
+++ b/lib/users.js
@@ -49,9 +49,9 @@ var getAllUsers = function(request, response, self) {
     };
   }
 
-  // Limit results to specific signup_application_id (affiliate / country code).
-  if (request.query.signup_application_id) {
-    conditions['signup_application_id'] = request.query.signup_application_id;
+  // Limit results to specific source (affiliate / country code).
+  if (request.query.source) {
+    conditions['source'] = request.query.source;
   }
 
   // Only return users who have taken campaign actions.
@@ -166,7 +166,7 @@ var getByBirthdate = function(request, response, self) {
     year: {$year: '$birthdate'},
     drupal_uid: '$drupal_uid',
     email: '$email',
-    signup_application_id: '$signup_application_id',
+    source: '$source',
     first_name: '$first_name',
     last_name: '$last_name',
     subscribed: '$subscribed',
@@ -239,9 +239,9 @@ var getByBirthdate = function(request, response, self) {
   }
   query.push(user_events);
 
-  // Limit results to specific signup_application_id (affiliate / country code).
-  if (request.query.signup_application_id) {
-    var source = {$match: {signup_application_id: request.query.signup_application_id}};
+  // Limit results to specific source (affiliate / country code).
+  if (request.query.source) {
+    var source = {$match: {source: request.query.source}};
     query.push(source);
   }
 
@@ -296,7 +296,7 @@ var getByDrupalRegisterDate = function(request, response, self) {
     year: {$year: '$drupal_register_date'},
     drupal_uid: '$drupal_uid',
     email: '$email',
-    signup_application_id: '$signup_application_id',
+    source: '$source',
     first_name: '$first_name',
     last_name: '$last_name',
     subscribed: '$subscribed',
@@ -367,9 +367,9 @@ var getByDrupalRegisterDate = function(request, response, self) {
   }
   query.push(user_events);
 
-  // Limit results to specific signup_application_id (affiliate / country code).
-  if (request.query.signup_application_id) {
-    var source = {$match: {signup_application_id: request.query.signup_application_id}};
+  // Limit results to specific ssource (affiliate / country code).
+  if (request.query.source) {
+    var source = {$match: {source: request.query.source}};
     query.push(source);
   }
 

--- a/mb-users-api-server.js
+++ b/mb-users-api-server.js
@@ -76,7 +76,7 @@ mongoose.connection.once('open', function() {
     birthdate: Date,
     drupal_register_date: Date,
     drupal_uid: Number,
-    signup_application_id: String,
+    source: String,
     first_name: String,
     last_name: String,
     address1: String,


### PR DESCRIPTION
Converts using `signup_application_id` to `source` to better reflect the possible values for the field in user documents. Possible values:
- Affiliate country code from Drupal sites, ex: `US`, `CA`, etc
- User imports, ex `niche`, `herCampus`

Fixes #72 
