### PR TITLE
Adds PM2 config file for app to run as daemon

### DIFF
--- a/mb-users-api-pm2.json
+++ b/mb-users-api-pm2.json
@@ -1,0 +1,24 @@
+{
+  "name"             : "mb-users-api-server",
+  "cwd"              : "/var/www/mb-users-api",
+  "script"           : "bin/mb-users-api-server.js",
+  "node_args"        : ["--harmony", " --max-stack-size=102400000"],
+  "log_date_format"  : "YYYY-MM-DD HH:mm Z",
+  "error_file"       : "/var/log/mb-users-api-server/mb-users-api-server.stderr.log",
+  "instances"        : 6, //or 0 => 'max'
+  "min_uptime"       : "200s", // 200 seconds, defaults to 1000
+  "max_restarts"     : 10, // defaults to 15
+  "max_memory_restart": "1M", // 1 megabytes, e.g.: "2G", "10M", "100K", 1024 the default unit is byte.
+  "cron_restart"     : "1 0 * * *",
+  "watch"            : true,
+  "ignore_watch"      : ["[\\/\\\\]\\./", "node_modules"],
+  "merge_logs"       : true,
+  "exec_interpreter" : "node",
+  "exec_mode"        : "cluster",
+  "instances"        : 0,
+  "autorestart"      : true, // enable/disable automatic restart when an app crashes or exits
+  "vizion"           : false, // enable/disable vizion features (versioning control)
+  "env": {
+    "NODE_ENV": "production"
+  }
+}


### PR DESCRIPTION
Fixes #87 

Moving from `forever` to `pm2` as daemon system on `mbc-node` server. The `mb-users-api-pm2.json` file is used by `pm2` to load processes based on settings in the file:
```
$ pm2 start mb-users-api-pm2.json
```