### PR TITLE
Issue92 global campaign language

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -2,6 +2,7 @@
  * Interface to the User model.
  */
 var dslogger = require('./dslogger');
+// var util = require('util');
 
 // For debugging, consider using util to output objects with console.log
 //    util = require('util');
@@ -206,9 +207,6 @@ User.prototype.post = function(req, res) {
         // Convert timestamps to Date objects.
         for(var i = 0; i < self.request.body.campaigns.length; i++) {
           var reqCampaign = self.request.body.campaigns[i];
-          if (reqCampaign.campaign_language) {
-            self.request.body.campaigns[i].language = reqCampaign.campaign_language;
-          }
           if (reqCampaign.signup) {
             self.request.body.campaigns[i].signup = convertToDate(reqCampaign.signup);
           }
@@ -218,6 +216,7 @@ User.prototype.post = function(req, res) {
         }
 
         if (doc && "campaigns" in doc) {
+
           // Add old campaigns data to ensure it doesn't get lost.
           updateArgs.campaigns = doc.campaigns;
 
@@ -231,8 +230,8 @@ User.prototype.post = function(req, res) {
 
               if (parseInt(reqCampaign.nid) === updateArgs.campaigns[j].nid) {
                 // Update only the fields provided by the request.
-                if (reqCampaign.campaign_language) {
-                  updateArgs.campaigns[j].language = reqCampaign.campaign_language;
+                if (reqCampaign.language) {
+                  updateArgs.campaigns[j].language = reqCampaign.language;
                 }
                 if (reqCampaign.signup) {
                   updateArgs.campaigns[j].signup = reqCampaign.signup;
@@ -258,7 +257,6 @@ User.prototype.post = function(req, res) {
           updateArgs.campaigns = self.request.body.campaigns;
         }
       }
-
       if ("subscriptions" in self.request.body) {
         updateArgs.subscriptions = {};
         var reqSubscriptions = self.request.body.subscriptions;
@@ -339,6 +337,7 @@ User.prototype.delete = function(request, response) {
  *  Response object to handle responses back to the sender.
  */
 User.prototype.updateUser = function(email, args, response) {
+
   var self = {};
   self.email = email;
   self.args = args;

--- a/lib/user.js
+++ b/lib/user.js
@@ -206,6 +206,9 @@ User.prototype.post = function(req, res) {
         // Convert timestamps to Date objects.
         for(var i = 0; i < self.request.body.campaigns.length; i++) {
           var reqCampaign = self.request.body.campaigns[i];
+          if (reqCampaign.campaign_language) {
+            self.request.body.campaigns[i].language = reqCampaign.campaign_language;
+          }
           if (reqCampaign.signup) {
             self.request.body.campaigns[i].signup = convertToDate(reqCampaign.signup);
           }
@@ -228,10 +231,12 @@ User.prototype.post = function(req, res) {
 
               if (parseInt(reqCampaign.nid) === updateArgs.campaigns[j].nid) {
                 // Update only the fields provided by the request.
+                if (reqCampaign.campaign_language) {
+                  updateArgs.campaigns[j].language = reqCampaign.campaign_language;
+                }
                 if (reqCampaign.signup) {
                   updateArgs.campaigns[j].signup = reqCampaign.signup;
                 }
-
                 if (reqCampaign.reportback) {
                   updateArgs.campaigns[j].reportback = reqCampaign.reportback;
                 }

--- a/mb-users-api-server.js
+++ b/mb-users-api-server.js
@@ -112,6 +112,7 @@ mongoose.connection.once('open', function() {
     },
     campaigns:[{
       nid: Number,
+      language: String,
       signup: Date,
       reportback: Date
     }],


### PR DESCRIPTION
Fixes #92 

Adds support for `language` for user campaign activity POSTs to `/user`.

**Example POST**:

```
{
  "email": "dlee@dosomething.org",
  "subscribed": 1,
  "campaigns": [
    {
      "nid": 123,
      "language": "en-global",
      "signup": 1446503976
    }
  ]
}
```
